### PR TITLE
Fixed underlining compatibility with safari

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,7 @@
 .def-decoration {
     display: inline-block;
     border-bottom: 2px dotted var(--color-yellow);
+	line-height: 1;
 }
 
 .def-link-decoration {

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,8 @@
 }
 
 .def-decoration {
-	text-decoration: underline var(--color-yellow) dotted;
+    display: inline-block;
+    border-bottom: 2px dotted var(--color-yellow);
 }
 
 .def-link-decoration {


### PR DESCRIPTION
Fixes #71. Issue caused by text-decoration compatibility issues with Safari due to it being a WebKit based browser. Tested on iPad. Image below:

![Screenshot 2024-08-25 at 1 14 32 PM](https://github.com/user-attachments/assets/c6dc2fc6-27ce-4b9f-a26f-0eac00024f77)
