### PR TITLE
Support iOS/Safari WebKit text decoration #71

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,10 +17,12 @@
 
 .def-decoration {
 	text-decoration: underline var(--color-yellow) dotted;
+	-webkit-text-decoration: underline var(--color-yellow) dotted;
 }
 
 .def-link-decoration {
 	text-decoration: underline var(--color-green) dotted;
+	-webkit-text-decoration: underline var(--color-green) dotted;
 	cursor: pointer;
 }
 


### PR DESCRIPTION
Follow on from: https://github.com/dominiclet/obsidian-note-definitions/pull/75

Fixes https://github.com/dominiclet/obsidian-note-definitions/issues/71. 

BRAT installable version: https://github.com/christopherjsmith/obsidian-note-definitions-ipad


![image](https://github.com/user-attachments/assets/b851d181-47c5-4b4d-9907-f1958f455b30)


