### PR TITLE
Add Definition: Support empty consolidated definition files fixes #70

### DIFF
--- a/src/core/def-file-manager.ts
+++ b/src/core/def-file-manager.ts
@@ -274,7 +274,7 @@ export class DefManager {
 		this.globalDefFiles.set(file.path, file);
 		let parser = new FileParser(this.app, file);
 		const def = await parser.parseFile();
-		if (def.length > 0 && def[0].fileType === DefFileType.Consolidated) {
+		if (parser.defFileType === DefFileType.Consolidated) {
 			this.consolidatedDefFiles.set(file.path, file);
 		}
 		return def;

--- a/src/core/file-parser.ts
+++ b/src/core/file-parser.ts
@@ -13,7 +13,8 @@ export enum DefFileType {
 
 export class FileParser {
 	app: App;
-	file: TFile;
+	file: TFile
+	defFileType?: DefFileType;
 
 	constructor(app: App, file: TFile) {
 		this.app = app;
@@ -23,9 +24,9 @@ export class FileParser {
 	// Optional argument used when file cache may not be updated
 	// and we know the new contents of the file
 	async parseFile(fileContent?: string): Promise<Definition[]> {
-		const defFileType = this.getDefFileType();
+		this.defFileType = this.getDefFileType();
 
-		switch (defFileType) {
+		switch (this.defFileType) {
 			case DefFileType.Consolidated:
 				const defParser = new ConsolidatedDefParser(this.app, this.file);
 				return defParser.parseFile(fileContent);


### PR DESCRIPTION
Fixes https://github.com/dominiclet/obsidian-note-definitions/issues/70

**Root cause**: file type identification was based on the first entry present in the file. 
**Solution**: Use file meta-data or plugin default to identify file type

_Note_: Will need the following files up versioning accordingly on merge before release is built.
* `manifest.json`
* `versions.json`

BRAT installable version: https://github.com/christopherjsmith/obsidian-note-definitions-ipad

![image](https://github.com/user-attachments/assets/eec19ac1-32df-4bb7-989d-f70964e358a0)

