### PR TITLE
[Patch] Bind mobile Markdown renderer to source file. Fixes #85

### DIFF
--- a/src/editor/mobile/definition-modal.ts
+++ b/src/editor/mobile/definition-modal.ts
@@ -1,4 +1,4 @@
-import { App, Component, MarkdownRenderer, Modal } from "obsidian";
+import { App, Component, MarkdownRenderer, normalizePath, Modal } from "obsidian";
 import { Definition } from "src/core/model";
 
 let defModal: DefinitionModal;
@@ -27,7 +27,7 @@ export class DefinitionModal extends Component {
 			}
 		});
 		MarkdownRenderer.render(this.app, definition.definition, defContent,
-			this.app.workspace.getActiveFile()?.path ?? '', this);
+			normalizePath(definition.file.path) ?? '', this);
 		this.modal.open();
 	}
 }


### PR DESCRIPTION
Fix for #85

The mobile specific modal binds the Markdown renderer context to the file hosting, rather than the file it is rendering. This will cause all internal links to calculate incorrectly and mess with things like dataview/dataviewjs.

Sample definition file:
[Coração.md](https://github.com/user-attachments/files/17193626/Coracao.md)

Before fix:
![image](https://github.com/user-attachments/assets/c3e35f37-2797-438d-89e4-0863a2e9a1ce)

After fix:
![image](https://github.com/user-attachments/assets/0a9780ab-cfcf-44c0-ae5c-948031415147)
