### PR TITLE
[Minor] Add support for auto plurals -- English only

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
+	},
+	"dependencies": {
+		"pluralize": "^8.0.0"
 	}
 }

--- a/src/core/atomic-def-parser.ts
+++ b/src/core/atomic-def-parser.ts
@@ -1,15 +1,15 @@
-import { App, CachedMetadata, TFile } from "obsidian";
+import { BaseDefParser } from "./base-def-parser";
+import { App, TFile } from "obsidian";
 import { DefFileType } from "./file-parser";
 import { Definition } from "./model";
 
 
-export class AtomicDefParser {
+export class AtomicDefParser extends BaseDefParser {
 	app: App;
 	file: TFile;
 
 	constructor(app: App, file: TFile) {
-		this.app = app;
-		this.file = file;
+		super(app, file);
 	}
 
 	async parseFile(fileContent?: string): Promise<Definition[]> {
@@ -30,6 +30,8 @@ export class AtomicDefParser {
 		if (fmPos) {
 			fileContent = fileContent.slice(fmPos.end.offset+1);
 		}
+
+		aliases = aliases.concat(this.calculatePlurals([this.file.basename].concat(aliases)));
 
 		const def = {
 			key: this.file.basename.toLowerCase(),

--- a/src/core/base-def-parser.ts
+++ b/src/core/base-def-parser.ts
@@ -1,0 +1,35 @@
+import { App, TFile } from "obsidian";
+import { DefFileParseConfig, getSettings } from "src/settings";
+
+var pluralize = require('pluralize');
+
+export class BaseDefParser {
+    app: App;
+	file: TFile;
+    
+    constructor(app: App, file: TFile) {
+		this.app = app;
+		this.file = file;
+	}
+
+    calculatePlurals(aliases: string[]) {
+        let plurals: string[] = [];
+
+        if (this.getParseSettings().autoPlurals)
+        {
+            aliases.forEach(alias => {
+                let pl = pluralize(alias);
+                if (pl !== alias)
+                {
+                    plurals.push(pl)
+                }
+            })
+        }
+
+		return plurals;
+    }
+    
+    getParseSettings(): DefFileParseConfig {
+		return getSettings().defFileParseConfig;
+	}
+}

--- a/src/core/consolidated-def-parser.ts
+++ b/src/core/consolidated-def-parser.ts
@@ -1,12 +1,13 @@
 import { App, TFile } from "obsidian";
-import { DefFileParseConfig, getSettings } from "src/settings";
+import { BaseDefParser } from "./base-def-parser";
 import { DefFileType } from "./file-parser";
 import { Definition, FilePosition } from "./model";
 
 
-export class ConsolidatedDefParser {
+export class ConsolidatedDefParser extends BaseDefParser {
 	app: App;
 	file: TFile;
+
 	defBuffer: {
 		word?: string;
 		aliases?: string[];
@@ -19,8 +20,8 @@ export class ConsolidatedDefParser {
 	currLine: number;
 
 	constructor(app: App, file: TFile) {
-		this.app = app;
-		this.file = file;
+		super(app, file);
+
 		this.defBuffer = {};
 		this.inDefinition = false;
 		this.definitions = [];
@@ -84,6 +85,9 @@ export class ConsolidatedDefParser {
 	}
 
 	private commitDefBuffer() {
+		const aliases = [this.defBuffer.word ?? ""].concat(this.defBuffer.aliases ?? []);
+		this.defBuffer.aliases = aliases.concat(this.calculatePlurals(aliases));
+
 		// Register word
 		this.definitions.push({
 			key: this.defBuffer.word?.toLowerCase() ?? "",
@@ -157,9 +161,5 @@ export class ConsolidatedDefParser {
 
 	private startNewBlock() {
 		this.inDefinition = false;
-	}
-
-	private getParseSettings(): DefFileParseConfig {
-		return getSettings().defFileParseConfig;
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -20,6 +20,7 @@ export interface DividerSettings {
 export interface DefFileParseConfig {
 	defaultFileType: DefFileType;
 	divider: DividerSettings;
+	autoPlurals: boolean;
 }
 
 export interface DefinitionPopoverConfig {
@@ -51,7 +52,8 @@ export const DEFAULT_SETTINGS: Partial<Settings> = {
 		divider: {
 			dash: true,
 			underscore: false
-		}
+		},
+		autoPlurals: false
 	},
 	defPopoverConfig: {
 		displayAliases: true,
@@ -155,6 +157,17 @@ export class SettingsTab extends PluginSettingTab {
 				component.setValue(this.settings.defFileParseConfig.defaultFileType ?? DefFileType.Consolidated);
 				component.onChange(async val => {
 					this.settings.defFileParseConfig.defaultFileType = val as DefFileType;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName("Automatically detect plurals -- English only")
+			.setDesc("Attempt to automatically generate aliases for words using English pluralisation rules")
+			.addToggle((component) => {
+				component.setValue(this.settings.defFileParseConfig.autoPlurals);
+				component.onChange(async (val) => {
+					this.settings.defFileParseConfig.autoPlurals = val;
 					await this.plugin.saveSettings();
 				});
 			});


### PR DESCRIPTION
Feature request #82 

Adds a new feature, defaulting to off. We generates automatic aliases for the plural version of words.

It only supports English, and is certainly not perfect. But in many cases will make writing notes in English significantly more fluent.

Unfortuantely the original plan to detect language and pluralise isn't possible without writing the rules for every language.

This solution utilises:
https://www.npmjs.com/package/pluralize

New setting: default false.
![image](https://github.com/user-attachments/assets/663e4f72-34c6-4f21-9b20-7c23f08de4d3)


BRAT installable version: https://github.com/christopherjsmith/obsidian-note-definitions-ipad