### PR TITLE
Button to create new folder from add modal

### DIFF
--- a/src/core/def-file-manager.ts
+++ b/src/core/def-file-manager.ts
@@ -155,6 +155,7 @@ export class DefManager {
 		this.globalPrefixTree = new PTreeNode();
 		this.globalDefs.clear();
 		this.globalDefFiles = new Map<string, TFile>();
+		this.globalDefFolders = new Map<string, TFolder>;
 	}
 
 	// Load all definitions from registered def folder
@@ -278,6 +279,16 @@ export class DefManager {
 			this.consolidatedDefFiles.set(file.path, file);
 		}
 		return def;
+	}
+
+	ensureGlobalDefFolder() {
+		const folderPath = this.getGlobalDefFolder();
+		const folder = this.app.vault.getAbstractFileByPath(folderPath);
+		if (folder) {
+			return null;
+		}
+		this.app.vault.createFolder(folderPath);
+		return folderPath;
 	}
 
 	getGlobalDefFolder() {

--- a/src/editor/add-modal.ts
+++ b/src/editor/add-modal.ts
@@ -109,7 +109,6 @@ export class AddDefinitionModal {
 				};
 				this.atomicFolderPicker.addOption(globalFolderPath, globalFolderPath + "/");
 			});
-		//this.newFolderButton.buttonEl.hide();
 
 		const button = this.modal.contentEl.createEl("button", {
 			text: "Save",

--- a/src/editor/add-modal.ts
+++ b/src/editor/add-modal.ts
@@ -66,13 +66,11 @@ export class AddDefinitionModal {
 				component.addOption(DefFileType.Atomic, "Atomic");
 				component.onChange(val => {
 					if (val === DefFileType.Consolidated) {
-						this.newFolderButton.buttonEl.hide();
 						this.atomicFolderPickerSetting.settingEl.hide();
 						this.defFilePickerSetting.settingEl.show();
 					} else if (val === DefFileType.Atomic) {
 						this.defFilePickerSetting.settingEl.hide();
 						this.atomicFolderPickerSetting.settingEl.show();
-						this.newFolderButton.buttonEl.show();
 					}
 				});
 				this.fileTypePicker = component;
@@ -111,7 +109,7 @@ export class AddDefinitionModal {
 				};
 				this.atomicFolderPicker.addOption(globalFolderPath, globalFolderPath + "/");
 			});
-		this.newFolderButton.buttonEl.hide();
+		//this.newFolderButton.buttonEl.hide();
 
 		const button = this.modal.contentEl.createEl("button", {
 			text: "Save",

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,6 +198,14 @@ export default class NoteDefinition extends Plugin {
 				this.refreshDefinitions();
 			}
 		}));
+
+		this.registerEvent(this.app.vault.on('delete', (file) => {
+			const settings = getSettings();
+			if (file.path.startsWith(settings.defFolder)) {
+				this.fileExplorerDeco.run();
+				this.refreshDefinitions();
+			}
+		}));
 	}
 
 	registerMenuForMarkedWords(menu: Menu, def: Definition) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -101,7 +101,6 @@ export class SettingsTab extends PluginSettingTab {
 					this.settings.defFolder = val;
 					await this.plugin.saveSettings();
 				});
-				// component.setDisabled(true)
 				setTooltip(component.inputEl, 
 					"In the file explorer, right-click on the desired folder and click on 'Set definition folder' to change the definition folder",
 				{

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -97,7 +97,11 @@ export class SettingsTab extends PluginSettingTab {
 			.addText((component) => {
 				component.setValue(this.settings.defFolder);
 				component.setPlaceholder(DEFAULT_DEF_FOLDER);
-				component.setDisabled(true)
+				component.onChange(async (val) => {
+					this.settings.defFolder = val;
+					await this.plugin.saveSettings();
+				});
+				// component.setDisabled(true)
 				setTooltip(component.inputEl, 
 					"In the file explorer, right-click on the desired folder and click on 'Set definition folder' to change the definition folder",
 				{

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -97,10 +97,7 @@ export class SettingsTab extends PluginSettingTab {
 			.addText((component) => {
 				component.setValue(this.settings.defFolder);
 				component.setPlaceholder(DEFAULT_DEF_FOLDER);
-				component.onChange(async (val) => {
-					this.settings.defFolder = val;
-					await this.plugin.saveSettings();
-				});
+				component.setDisabled(true);
 				setTooltip(component.inputEl, 
 					"In the file explorer, right-click on the desired folder and click on 'Set definition folder' to change the definition folder",
 				{

--- a/styles.css
+++ b/styles.css
@@ -52,3 +52,9 @@
 	float: right;
 	background-color: var(--interactive-normal);
 }
+
+.add-modal-new-folder-button {
+	font-size: var(--font-ui-medium);
+	float: left;
+	background-color: var(--interactive-normal);
+}


### PR DESCRIPTION
I added a button to the add modal that tries to create a global definitions folder based on the plugin setting (default is `definitions`). If that folder already exists, we show a notification. 

I also adjusted the validation logic that the add modal uses in order to more closely follow specification and fix #95. Together, this makes it a lot easier to begin from a clean vault if you don't care about creating custom directories.

Also added a delete event and tweaked the `defFileManager` `reset()` function to also clear the `globalDefFolders`, in order to remove ghost atomic folder options on the add modal. That may have unintended implications, but I didn't add any additional code to regenerate `globalDefFolders`; it seems that existing functionality keeps it up to date anyways. 