### PR TITLE
[Patch] Issue #114 - Duplicate definitions not respected with definition contexts

### DIFF
--- a/src/core/def-file-manager.ts
+++ b/src/core/def-file-manager.ts
@@ -26,7 +26,9 @@ export class DefManager {
 
 	activeFile: TFile | null;
 	localPrefixTree: PTreeNode;
-	shouldUseLocalPTree: boolean;
+	shouldUseLocal: boolean;
+
+	localDefs: DefinitionRepo;
 
 	constructor(app: App) {
 		this.app = app;
@@ -35,6 +37,8 @@ export class DefManager {
 		this.globalDefFolders = new Map<string, TFolder>();
 		this.globalPrefixTree = new PTreeNode();
 		this.consolidatedDefFiles = new Map<string, TFile>();
+		this.localDefs = new DefinitionRepo();
+
 		this.resetLocalConfigs()
 		this.lastUpdate = 0;
 		this.markedDirty = [];
@@ -50,7 +54,7 @@ export class DefManager {
 
 	// Get the appropriate prefix tree to use for current active file
 	getPrefixTree() {
-		if (this.shouldUseLocalPTree) {
+		if (this.shouldUseLocal) {
 			return this.localPrefixTree;
 		}
 		return this.globalPrefixTree;
@@ -59,7 +63,8 @@ export class DefManager {
 	// Updates active file and rebuilds local prefix tree if necessary
 	updateActiveFile() {
 		this.activeFile = this.app.workspace.getActiveFile();
-		this.resetLocalConfigs()
+		this.resetLocalConfigs();
+
 		if (this.activeFile) {
 			const metadataCache = this.app.metadataCache.getFileCache(this.activeFile);
 			if (!metadataCache) {
@@ -71,12 +76,13 @@ export class DefManager {
 				return;
 			}
 			if (!Array.isArray(paths)) {
-				logWarn("Unrecognised type for 'def-source' frontmatter");
+				logWarn(`Unrecognised type for '${DEF_CTX_FM_KEY}' frontmatter`);
 				return;
 			}
 			const flattenedPaths = this.flattenPathList(paths);
 			this.buildLocalPrefixTree(flattenedPaths);
-			this.shouldUseLocalPTree = true;
+			this.buildLocalDefRepo(flattenedPaths);
+			this.shouldUseLocal = true;
 		}
 	}
 
@@ -84,7 +90,8 @@ export class DefManager {
 	updateDefSources(defSource: string[]) {
 		this.resetLocalConfigs();
 		this.buildLocalPrefixTree(defSource);
-		this.shouldUseLocalPTree = true;
+		this.buildLocalDefRepo(defSource);
+		this.shouldUseLocal = true;
 	}
 
 	markDirty(file: TFile) {
@@ -148,6 +155,16 @@ export class DefManager {
 		this.localPrefixTree = root;
 	}
 
+	// Expects an array of file paths (not directories)
+	private buildLocalDefRepo(filePaths: string[]) {
+		filePaths.forEach(filePath => {
+			const defMap = this.globalDefs.getMapForFile(filePath);
+			if (defMap) {
+				this.localDefs.fileDefMap.set(filePath, defMap);
+			}
+		});
+	}
+
 	isDefFile(file: TFile): boolean {
 		return file.path.startsWith(this.getGlobalDefFolder())
 	}
@@ -166,8 +183,12 @@ export class DefManager {
 		this.loadGlobals();
 	}
 
+	private getDefRepo() {
+		return this.shouldUseLocal ? this.localDefs : this.globalDefs;
+	}
+
 	get(key: string) {
-		return this.globalDefs.get(normaliseWord(key));
+		return this.getDefRepo().get(normaliseWord(key));
 	}
 
 	set(def: Definition) {
@@ -219,7 +240,8 @@ export class DefManager {
 	// Global configs should always be used by default
 	private resetLocalConfigs() {
 		this.localPrefixTree = new PTreeNode();
-		this.shouldUseLocalPTree = false;
+		this.shouldUseLocal = false;
+		this.localDefs.clear();
 	}
 
 	private async loadGlobals() {

--- a/src/core/def-file-manager.ts
+++ b/src/core/def-file-manager.ts
@@ -89,6 +89,10 @@ export class DefManager {
 	// For manually updating definition sources, as metadata cache may not be the latest updated version
 	updateDefSources(defSource: string[]) {
 		this.resetLocalConfigs();
+
+		if (!defSource || defSource.length === 0) {
+			return;
+		}
 		this.buildLocalPrefixTree(defSource);
 		this.buildLocalDefRepo(defSource);
 		this.shouldUseLocal = true;

--- a/src/core/def-file-manager.ts
+++ b/src/core/def-file-manager.ts
@@ -180,7 +180,7 @@ export class DefManager {
 	// Expensive operation so use sparingly
 	loadDefinitions() {
 		this.reset();
-		this.loadGlobals();
+		this.loadGlobals().then(this.updateActiveFile.bind(this));
 	}
 
 	private getDefRepo() {

--- a/src/editor/decoration.ts
+++ b/src/editor/decoration.ts
@@ -29,8 +29,10 @@ export function getMarkedPhrases(): PhraseInfo[] {
 // View plugin to mark definitions
 export class DefinitionMarker implements PluginValue {
 	decorations: DecorationSet;
+	editorView: EditorView;
 
 	constructor(view: EditorView) {
+		this.editorView = view;
 		this.decorations = this.buildDecorations(view);
 	}
 
@@ -42,6 +44,14 @@ export class DefinitionMarker implements PluginValue {
 			logDebug(`Marked definitions in ${end-start}ms`)
 			return
 		}
+	}
+
+	public forceUpdate() {
+		const start = performance.now();
+		this.decorations = this.buildDecorations(this.editorView);
+		const end = performance.now();
+		logDebug(`Marked definitions in ${end - start}ms`)
+		return;
 	}
 
 	destroy() {}

--- a/src/editor/frontmatter-suggest-modal.ts
+++ b/src/editor/frontmatter-suggest-modal.ts
@@ -33,9 +33,6 @@ export class FMSuggestModal extends FuzzySuggestModal<TAbstractFile> {
 			}
 			
 			fm[DEF_CTX_FM_KEY] = [...currDefSource, path];
-
-			// Reload internals
-			getDefFileManager().updateDefSources([...currDefSource, path]);
 		}).catch(e => {
 			logError(`Error writing to frontmatter of file: ${e}`);
 		});

--- a/src/editor/frontmatter-suggest-modal.ts
+++ b/src/editor/frontmatter-suggest-modal.ts
@@ -24,15 +24,14 @@ export class FMSuggestModal extends FuzzySuggestModal<TAbstractFile> {
 		const path = this.getPath(item);
 		this.app.fileManager.processFrontMatter(this.file, (fm) => {
 			let currDefSource = fm[DEF_CTX_FM_KEY];
+
 			if (!currDefSource || !Array.isArray(currDefSource)) {
-				fm[DEF_CTX_FM_KEY] = [path];
-				return;
-			}
-			// Check if file is already added
-			if (currDefSource.includes(path)) {
+				currDefSource = [];
+			} else if (currDefSource.includes(path)) {
 				new Notice("Definition file source is already included for this file");
 				return;
 			}
+			
 			fm[DEF_CTX_FM_KEY] = [...currDefSource, path];
 
 			// Reload internals


### PR DESCRIPTION
Previously we were building a localPTree based on the def context, but then looking in global defs for any matches. Which allowed us to match outside of the def-context.

Now I have introduced the concept of a local def repo too, and use that when we are using any definition contexts.

Two additional improvements have been made along side this:

1. If on opening obsidian a file was immediately open with def-contexts the local P tree wasn't correctly built. This was resolved by waiting for the initial def load then applying the active file: `this.loadGlobals().then(this.updateActiveFile.bind(this));`

2. Previously when using the Add Definition Context command, we would force update the content of the local P Tree. But we wouldn't trigger the file to actually updates the definition markers. So we added a `forceUpdate` function to the ViewPlugin to enable us to trigger this.

3. If a user manually updated the metadata to change the def contexts (the only way to delete at the moment) we wouldn't trigger any changes to the def files without a full change of the active file. This has been resolved by removing the manual update on `Add Definition Context` and instead using a `metadataCache.on('changed.,...)` listener. This catch both changes from the command, and manual user edits.

Fixes Issue #114 