### PR TITLE
Add additional checks to include only .md files as definition files

### DIFF
--- a/src/core/def-file-manager.ts
+++ b/src/core/def-file-manager.ts
@@ -170,7 +170,7 @@ export class DefManager {
 	}
 
 	isDefFile(file: TFile): boolean {
-		return file.path.startsWith(this.getGlobalDefFolder())
+		return file.path.startsWith(this.getGlobalDefFolder()) && (!window.NoteDefinition.settings.includeMarkdownFilesOnly || file.path.endsWith(".md"));
 	}
 
 	reset() {
@@ -289,7 +289,7 @@ export class DefManager {
 			if (f instanceof TFolder) {
 				let defs = await this.parseFolder(f);
 				definitions.push(...defs);
-			} else if (f instanceof TFile) {
+			} else if (f instanceof TFile && this.isDefFile(f)) {
 				let defs = await this.parseFile(f);
 				definitions.push(...defs);
 			}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,6 +37,7 @@ export interface Settings {
 	enableInReadingView: boolean;
 	enableSpellcheck: boolean;
 	defFolder: string;
+	includeMarkdownFilesOnly: boolean;
 	popoverEvent: PopoverEventSettings;
 	defFileParseConfig: DefFileParseConfig;
 	defPopoverConfig: DefinitionPopoverConfig;
@@ -47,6 +48,7 @@ export const DEFAULT_DEF_FOLDER = "definitions"
 export const DEFAULT_SETTINGS: Partial<Settings> = {
 	enableInReadingView: true,
 	enableSpellcheck: true,
+	includeMarkdownFilesOnly: false,
 	popoverEvent: PopoverEventSettings.Hover,
 	defFileParseConfig: {
 		defaultFileType: DefFileType.Consolidated,
@@ -118,6 +120,18 @@ export class SettingsTab extends PluginSettingTab {
 						delay: 100
 					});
 			});
+
+		new Setting(containerEl)
+			.setName("Include only markdown files in the definitions folder")
+			.setDesc("When enabled, only .md files in the definitions folder will be parsed.")
+			.addToggle((component) => {
+				component.setValue(this.settings.includeMarkdownFilesOnly);
+				component.onChange(async (val) => {
+					this.settings.includeMarkdownFilesOnly = val;
+					await this.saveCallback();
+				});
+			});
+
 		new Setting(containerEl)
 			.setName("Definition file format settings")
 			.setDesc("Customise parsing rules for definition files")

--- a/src/ui/file-explorer.ts
+++ b/src/ui/file-explorer.ts
@@ -59,7 +59,7 @@ export class FileExplorerDecoration {
 				return;
 			}
 
-			if (k.startsWith(defFolder)) {
+			if (k.startsWith(defFolder) && (!settings.includeMarkdownFilesOnly || k.endsWith(".md"))) {
 				this.tagFile(fileExpView, k, "DEF");
 			}
 		});


### PR DESCRIPTION
Implements the desired function in #128 

# Images

Additional setting field, off by default to ensure compatibility
![image](https://github.com/user-attachments/assets/3d0993aa-90cb-44a6-8a7b-e1318823c68a)

When enabled, there will be no error from attempting to parse image files. The non-md files will also no longer get marked as DEF in the file explorer.
![image](https://github.com/user-attachments/assets/5e524b8e-74de-45a3-829b-6684091845b6)
