### PR TITLE
feat: add per-word display modes, known words management, and custom …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-note-definitions",
-	"version": "0.28.3",
+	"version": "0.28.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-note-definitions",
-			"version": "0.28.3",
+			"version": "0.28.4",
 			"license": "MIT",
 			"dependencies": {
 				"pluralize": "^8.0.0"

--- a/src/core/atomic-def-parser.ts
+++ b/src/core/atomic-def-parser.ts
@@ -36,7 +36,7 @@ export class AtomicDefParser extends BaseDefParser {
 
 		aliases = aliases.concat(this.calculatePlurals([this.file.basename].concat(aliases)));
 
-		const def = {
+		const def: Definition = {
 			key: this.file.basename.toLowerCase(),
 			word: this.file.basename,
 			aliases: aliases,
@@ -45,6 +45,20 @@ export class AtomicDefParser extends BaseDefParser {
 			linkText: `${this.file.path}`,
 			fileType: DefFileType.Atomic,
 		}
+
+		// Add optional display settings from frontmatter
+		if (fmData) {
+			const displayMode = fmData["display-mode"];
+			const highlightStyle = fmData["highlight-style"];
+
+			if (displayMode === 'first-only' || displayMode === 'all-occurrences') {
+				def.displayMode = displayMode;
+			}
+			if (highlightStyle === 'box' || highlightStyle === 'underline') {
+				def.highlightStyle = highlightStyle;
+			}
+		}
+
 		return [def];
 	}
 }

--- a/src/core/model.ts
+++ b/src/core/model.ts
@@ -1,6 +1,9 @@
 import { TFile } from "obsidian";
 import { DefFileType } from "./file-type";
 
+export type DisplayMode = 'first-only' | 'all-occurrences';
+export type HighlightStyle = 'box' | 'underline';
+
 export interface Definition {
 	key: string;
 	word: string;
@@ -10,6 +13,8 @@ export interface Definition {
 	linkText: string;
 	fileType: DefFileType;
 	position?: FilePosition;
+	displayMode?: DisplayMode;
+	highlightStyle?: HighlightStyle;
 }
 
 export interface FilePosition {

--- a/src/editor/decoration.ts
+++ b/src/editor/decoration.ts
@@ -12,6 +12,8 @@ import { logDebug } from "src/util/log";
 import { DEF_DECORATION_CLS, getDecorationAttrs } from "./common";
 import { LineScanner } from "./definition-search";
 import { PTreeNode } from "./prefix-tree";
+import { getDefFileManager } from "src/core/def-file-manager";
+import { getSettings } from "src/settings";
 
 // Information of phrase that can be used to add decorations within the editor
 interface PhraseInfo {
@@ -59,21 +61,58 @@ export class DefinitionMarker implements PluginValue {
 	buildDecorations(view: EditorView): DecorationSet {
 		const builder = new RangeSetBuilder<Decoration>();
 		const phraseInfos: PhraseInfo[] = [];
+		const settings = getSettings();
+		const defManager = getDefFileManager();
 
 		for (let { from, to } of view.visibleRanges) {
 			const text = view.state.sliceDoc(from, to);
 			phraseInfos.push(...scanText(text, from));
 		}
 
+		const filteredPhrases: PhraseInfo[] = [];
+
 		phraseInfos.forEach(wordPos => {
+			const def = defManager.get(wordPos.phrase);
+			if (!def) return;
+
+			// Skip if word is in known words list
+			if (settings.knownWords.includes(def.key)) {
+				return;
+			}
+
+			// Check first-occurrence mode
+			if (def.displayMode === 'first-only') {
+				const tracking = settings.firstOccurrenceTracking[def.key];
+				if (tracking) {
+					// Already shown before, skip it
+					return;
+				} else {
+					// First occurrence! Track it
+					const activeFile = window.NoteDefinition.app.workspace.getActiveFile();
+					settings.firstOccurrenceTracking[def.key] = {
+						file: activeFile?.path || '',
+						position: wordPos.from
+					};
+					// Note: Settings will be saved on plugin unload or settings change
+				}
+			}
+
+			// Determine CSS class based on highlight style
+			let cssClass = DEF_DECORATION_CLS;
+			if (def.highlightStyle === 'box') {
+				cssClass = 'def-decoration-box';
+			}
+
 			const attributes = getDecorationAttrs(wordPos.phrase);
 			builder.add(wordPos.from, wordPos.to, Decoration.mark({
-				class: DEF_DECORATION_CLS,
+				class: cssClass,
 				attributes: attributes,
 			}));
+
+			filteredPhrases.push(wordPos);
 		});
 
-		markedPhrases = phraseInfos;
+		markedPhrases = filteredPhrases;
 		return builder.finish();
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -238,6 +238,35 @@ export default class NoteDefinition extends Plugin {
 					editModal.open(def);
 				});
 		});
+
+		// Add mark as known/unknown option
+		const settings = getSettings();
+		const isKnown = settings.knownWords.includes(def.key);
+
+		menu.addItem(item => {
+			if (isKnown) {
+				item.setTitle("Mark as unknown")
+					.setIcon("eye")
+					.onClick(async () => {
+						const index = settings.knownWords.indexOf(def.key);
+						if (index > -1) {
+							settings.knownWords.splice(index, 1);
+							await this.saveSettings();
+							new Notice(`"${def.word}" marked as unknown`);
+						}
+					});
+			} else {
+				item.setTitle("Mark as known")
+					.setIcon("eye-off")
+					.onClick(async () => {
+						if (!settings.knownWords.includes(def.key)) {
+							settings.knownWords.push(def.key);
+							await this.saveSettings();
+							new Notice(`"${def.word}" marked as known`);
+						}
+					});
+			}
+		});
 	}
 
 	refreshDefinitions() {

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,15 @@
 	-webkit-text-decoration: underline var(--color-yellow) dotted;
 }
 
+.def-decoration-box {
+	border: 1.5px solid gold;
+	border-radius: 3px;
+	padding: 1px 2px;
+	background-color: rgba(255, 215, 0, 0.1);
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+}
+
 .def-link-decoration {
 	text-decoration: underline var(--color-green) dotted;
 	-webkit-text-decoration: underline var(--color-green) dotted;


### PR DESCRIPTION
…highlight styles

This commit adds several new features to enhance word definition management:

1. **Per-word display modes**: Definition files can now specify `display-mode: first-only` or `display-mode: all-occurrences` in frontmatter to control whether a word is highlighted only on its first occurrence or every time it appears in the vault.

2. **Known words management**: Users can now mark words as "known" to hide them from being highlighted. A new settings panel allows viewing and managing the list of known words. Right-click on any highlighted word to mark it as known or unknown.

3. **Custom highlight styles**: Definition files can specify `highlight-style: box` or `highlight-style: underline` in frontmatter. The box style uses a gold border with subtle background, while underline uses the existing dotted underline.

4. **First-occurrence tracking**: When using `display-mode: first-only`, the plugin tracks where each word was first shown across the entire vault. A disclaimer in settings explains that this may not align with reading order if documents are read out of sequence.

Technical changes:
- Added `knownWords` and `firstOccurrenceTracking` to Settings interface
- Extended Definition model with `displayMode` and `highlightStyle` properties
- Updated both atomic and consolidated parsers to read new frontmatter properties
- Modified decoration logic in both editor and reading views to respect new settings
- Added new CSS class `def-decoration-box` for box-style highlights
- Added context menu option to mark/unmark words as known