### PR TITLE
Updated 'Add Definition' modal to default to the current file's conte…

### DIFF
--- a/src/editor/add-modal.ts
+++ b/src/editor/add-modal.ts
@@ -92,7 +92,6 @@ export class AddDefinitionModal {
 						const paths =
 							metadataCache?.frontmatter?.[DEF_CTX_FM_KEY];
 						if (paths) {
-							console.log(`NOTEDEF paths: ${paths}`);
 							val = paths[0];
 						}
 					}
@@ -188,8 +187,8 @@ export class AddDefinitionModal {
 					word: phraseText.value,
 					aliases: aliasText.value
 						? aliasText.value
-								.split(",")
-								.map((alias) => alias.trim())
+							.split(",")
+							.map((alias) => alias.trim())
 						: [],
 					definition: defText.value,
 					file: definitionFile,


### PR DESCRIPTION
…xt, if available

Does as the title says, adresses #153 

I'm relatively unfamiliar with obsidian plugin development, so there may be a better/more performant way to query the currently opened file's definition context, but this works as far as my testing could tell.