### PR TITLE
Update modals

### DIFF
--- a/src/editor/add-modal.ts
+++ b/src/editor/add-modal.ts
@@ -117,7 +117,7 @@ export class AddDefinitionModal {
 				});
 
 				// use the first definition file from this file's metadata, or default to
-				// the first folder in the list if it exists
+				// the first consolidated def file in the list if it exists
 				if (default_def_file) {
 					component.setValue(default_def_file);
 				} else if (defFiles.length > 0) {
@@ -167,22 +167,6 @@ export class AddDefinitionModal {
 					window.NoteDefinition.settings.defFileParseConfig
 						.defaultFileType,
 				);
-
-				// attempt to automatically determine the definition type we should use if there
-				// is at least one item in the definition context and the setting is enabled
-				if (
-					window.NoteDefinition.settings.defModalsConfig
-						.automaticallyDetermineNewDefTypes &&
-					paths
-				) {
-					// automatically determine the definition file type to default to based on
-					// the first item in the definition context list
-					if (paths[0] == default_def_file) {
-						component.setValue("consolidated");
-					} else if (paths[0] == default_def_folder + "/") {
-						component.setValue("atomic");
-					}
-				}
 
 				component.onChange(handleDefFileTypeChange);
 				handleDefFileTypeChange(component.getValue());

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,22 +1,14 @@
-import {
-	App,
-	Modal,
-	Notice,
-	Plugin,
-	PluginSettingTab,
-	Setting,
-	setTooltip,
-} from "obsidian";
+import { App, Modal, Notice, Plugin, PluginSettingTab, Setting, setTooltip } from "obsidian";
 import { DefFileType } from "./core/file-type";
 
 export enum PopoverEventSettings {
 	Hover = "hover",
-	Click = "click",
+	Click = "click"
 }
 
 export enum PopoverDismissType {
 	Click = "click",
-	MouseExit = "mouse_exit",
+	MouseExit = "mouse_exit"
 }
 
 export interface DividerSettings {
@@ -28,10 +20,6 @@ export interface DefFileParseConfig {
 	defaultFileType: DefFileType;
 	divider: DividerSettings;
 	autoPlurals: boolean;
-}
-
-export interface DefinitionModalsConfig {
-	automaticallyDetermineNewDefTypes: boolean;
 }
 
 export interface DefinitionPopoverConfig {
@@ -51,13 +39,12 @@ export interface Settings {
 	defFolder: string;
 	popoverEvent: PopoverEventSettings;
 	defFileParseConfig: DefFileParseConfig;
-	defModalsConfig: DefinitionModalsConfig;
 	defPopoverConfig: DefinitionPopoverConfig;
 }
 
-export const VALID_DEFINITION_FILE_TYPES = [".md"];
+export const VALID_DEFINITION_FILE_TYPES = [ ".md" ]
 
-export const DEFAULT_DEF_FOLDER = "definitions";
+export const DEFAULT_DEF_FOLDER = "definitions"
 
 export const DEFAULT_SETTINGS: Partial<Settings> = {
 	enableInReadingView: true,
@@ -67,12 +54,9 @@ export const DEFAULT_SETTINGS: Partial<Settings> = {
 		defaultFileType: DefFileType.Consolidated,
 		divider: {
 			dash: true,
-			underscore: false,
+			underscore: false
 		},
-		autoPlurals: false,
-	},
-	defModalsConfig: {
-		automaticallyDetermineNewDefTypes: true,
+		autoPlurals: false
 	},
 	defPopoverConfig: {
 		displayAliases: true,
@@ -82,8 +66,8 @@ export const DEFAULT_SETTINGS: Partial<Settings> = {
 		maxHeight: 150,
 		popoverDismissEvent: PopoverDismissType.Click,
 		enableDefinitionLink: false,
-	},
-};
+	}
+}
 
 export class SettingsTab extends PluginSettingTab {
 	plugin: Plugin;
@@ -104,9 +88,7 @@ export class SettingsTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Enable in Reading View")
-			.setDesc(
-				"Allow defined phrases and definition popovers to be shown in Reading View",
-			)
+			.setDesc("Allow defined phrases and definition popovers to be shown in Reading View")
 			.addToggle((component) => {
 				component.setValue(this.settings.enableInReadingView);
 				component.onChange(async (val) => {
@@ -127,57 +109,40 @@ export class SettingsTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Definitions folder")
-			.setDesc(
-				"Files within this folder will be parsed to register definitions",
-			)
+			.setDesc("Files within this folder will be parsed to register definitions")
 			.addText((component) => {
 				component.setValue(this.settings.defFolder);
 				component.setPlaceholder(DEFAULT_DEF_FOLDER);
-				component.setDisabled(true);
-				setTooltip(
-					component.inputEl,
+				component.setDisabled(true)
+				setTooltip(component.inputEl,
 					"In the file explorer, right-click on the desired folder and click on 'Set definition folder' to change the definition folder",
 					{
-						delay: 100,
-					},
-				);
+						delay: 100
+					});
 			});
 
 		new Setting(containerEl)
 			.setName("Definition file format settings")
 			.setDesc("Customise parsing rules for definition files")
-			.addExtraButton((component) => {
+			.addExtraButton(component => {
 				component.onClick(() => {
 					const modal = new Modal(this.app);
-					modal.setTitle("Definition file format settings");
+					modal.setTitle("Definition file format settings")
 					new Setting(modal.contentEl)
 						.setName("Divider")
-						.setHeading();
+						.setHeading()
 					new Setting(modal.contentEl)
 						.setName("Dash")
 						.setDesc("Use triple dash (---) as divider")
 						.addToggle((component) => {
-							component.setValue(
-								this.settings.defFileParseConfig.divider.dash,
-							);
-							component.onChange(async (value) => {
-								if (
-									!value &&
-									!this.settings.defFileParseConfig.divider
-										.underscore
-								) {
-									new Notice(
-										"At least one divider must be chosen",
-										2000,
-									);
-									component.setValue(
-										this.settings.defFileParseConfig.divider
-											.dash,
-									);
+							component.setValue(this.settings.defFileParseConfig.divider.dash);
+							component.onChange(async value => {
+								if (!value && !this.settings.defFileParseConfig.divider.underscore) {
+									new Notice("At least one divider must be chosen", 2000);
+									component.setValue(this.settings.defFileParseConfig.divider.dash);
 									return;
 								}
-								this.settings.defFileParseConfig.divider.dash =
-									value;
+								this.settings.defFileParseConfig.divider.dash = value;
 								await this.saveCallback();
 							});
 						});
@@ -185,80 +150,39 @@ export class SettingsTab extends PluginSettingTab {
 						.setName("Underscore")
 						.setDesc("Use triple underscore (___) as divider")
 						.addToggle((component) => {
-							component.setValue(
-								this.settings.defFileParseConfig.divider
-									.underscore,
-							);
-							component.onChange(async (value) => {
-								if (
-									!value &&
-									!this.settings.defFileParseConfig.divider
-										.dash
-								) {
-									new Notice(
-										"At least one divider must be chosen",
-										2000,
-									);
-									component.setValue(
-										this.settings.defFileParseConfig.divider
-											.underscore,
-									);
+							component.setValue(this.settings.defFileParseConfig.divider.underscore);
+							component.onChange(async value => {
+								if (!value && !this.settings.defFileParseConfig.divider.dash) {
+									new Notice("At least one divider must be chosen", 2000);
+									component.setValue(this.settings.defFileParseConfig.divider.underscore);
 									return;
 								}
-								this.settings.defFileParseConfig.divider.underscore =
-									value;
+								this.settings.defFileParseConfig.divider.underscore = value;
 								await this.saveCallback();
 							});
 						});
 					modal.open();
-				});
+				})
 			});
 
 		new Setting(containerEl)
 			.setName("Default definition file type")
-			.setDesc(
-				"When the 'def-type' frontmatter is not specified, the definition file will be treated as this configured default file type.",
-			)
-			.addDropdown((component) => {
+			.setDesc("When the 'def-type' frontmatter is not specified, the definition file will be treated as this configured default file type.")
+			.addDropdown(component => {
 				component.addOption(DefFileType.Consolidated, "consolidated");
 				component.addOption(DefFileType.Atomic, "atomic");
-				component.setValue(
-					this.settings.defFileParseConfig.defaultFileType ??
-						DefFileType.Consolidated,
-				);
-				component.onChange(async (val) => {
-					this.settings.defFileParseConfig.defaultFileType =
-						val as DefFileType;
-					await this.saveCallback();
-				});
-			});
-
-		new Setting(containerEl)
-			.setName("Automatically determine new definition file type")
-			.setDesc(
-				"Have the plugin automatically select whether a new definition will be atomic or consolidated based on the current note's frontmatter.",
-			)
-			.addToggle((component) => {
-				component.setValue(
-					this.settings.defModalsConfig
-						.automaticallyDetermineNewDefTypes ?? true,
-				);
-				component.onChange(async (val) => {
-					this.settings.defModalsConfig.automaticallyDetermineNewDefTypes =
-						val;
+				component.setValue(this.settings.defFileParseConfig.defaultFileType ?? DefFileType.Consolidated);
+				component.onChange(async val => {
+					this.settings.defFileParseConfig.defaultFileType = val as DefFileType;
 					await this.saveCallback();
 				});
 			});
 
 		new Setting(containerEl)
 			.setName("Automatically detect plurals -- English only")
-			.setDesc(
-				"Attempt to automatically generate aliases for words using English pluralisation rules",
-			)
+			.setDesc("Attempt to automatically generate aliases for words using English pluralisation rules")
 			.addToggle((component) => {
-				component.setValue(
-					this.settings.defFileParseConfig.autoPlurals,
-				);
+				component.setValue(this.settings.defFileParseConfig.autoPlurals);
 				component.onChange(async (val) => {
 					this.settings.defFileParseConfig.autoPlurals = val;
 					await this.saveCallback();
@@ -271,26 +195,17 @@ export class SettingsTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Definition popover display event")
-			.setDesc(
-				"Choose the trigger event for displaying the definition popover",
-			)
+			.setDesc("Choose the trigger event for displaying the definition popover")
 			.addDropdown((component) => {
 				component.addOption(PopoverEventSettings.Hover, "Hover");
 				component.addOption(PopoverEventSettings.Click, "Click");
 				component.setValue(this.settings.popoverEvent);
-				component.onChange(async (value) => {
-					if (
-						value === PopoverEventSettings.Hover ||
-						value === PopoverEventSettings.Click
-					) {
+				component.onChange(async value => {
+					if (value === PopoverEventSettings.Hover || value === PopoverEventSettings.Click) {
 						this.settings.popoverEvent = value;
 					}
-					if (
-						this.settings.popoverEvent ===
-						PopoverEventSettings.Click
-					) {
-						this.settings.defPopoverConfig.popoverDismissEvent =
-							PopoverDismissType.Click;
+					if (this.settings.popoverEvent === PopoverEventSettings.Click) {
+						this.settings.defPopoverConfig.popoverDismissEvent = PopoverDismissType.Click;
 					}
 					await this.saveCallback();
 					this.display();
@@ -300,30 +215,18 @@ export class SettingsTab extends PluginSettingTab {
 		if (this.settings.popoverEvent === PopoverEventSettings.Hover) {
 			new Setting(containerEl)
 				.setName("Definition popover dismiss event")
-				.setDesc(
-					"Configure the manner in which you would like to close/dismiss the definition popover.",
-				)
-				.addDropdown((component) => {
+				.setDesc("Configure the manner in which you would like to close/dismiss the definition popover.")
+				.addDropdown(component => {
 					component.addOption(PopoverDismissType.Click, "Click");
-					component.addOption(
-						PopoverDismissType.MouseExit,
-						"Mouse exit",
-					);
+					component.addOption(PopoverDismissType.MouseExit, "Mouse exit")
 					if (!this.settings.defPopoverConfig.popoverDismissEvent) {
-						this.settings.defPopoverConfig.popoverDismissEvent =
-							PopoverDismissType.Click;
+						this.settings.defPopoverConfig.popoverDismissEvent = PopoverDismissType.Click;
 						this.saveCallback();
 					}
-					component.setValue(
-						this.settings.defPopoverConfig.popoverDismissEvent,
-					);
-					component.onChange(async (value) => {
-						if (
-							value === PopoverDismissType.MouseExit ||
-							value === PopoverDismissType.Click
-						) {
-							this.settings.defPopoverConfig.popoverDismissEvent =
-								value;
+					component.setValue(this.settings.defPopoverConfig.popoverDismissEvent);
+					component.onChange(async value => {
+						if (value === PopoverDismissType.MouseExit || value === PopoverDismissType.Click) {
+							this.settings.defPopoverConfig.popoverDismissEvent = value;
 						}
 						await this.saveCallback();
 					});
@@ -332,27 +235,22 @@ export class SettingsTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Display aliases")
-			.setDesc(
-				"Display the list of aliases configured for the definition",
-			)
-			.addToggle((component) => {
-				component.setValue(
-					this.settings.defPopoverConfig.displayAliases,
-				);
-				component.onChange(async (value) => {
+			.setDesc("Display the list of aliases configured for the definition")
+			.addToggle(component => {
+				component.setValue(this.settings.defPopoverConfig.displayAliases);
+				component.onChange(async value => {
 					this.settings.defPopoverConfig.displayAliases = value;
 					await this.saveCallback();
 				});
 			});
 
+
 		new Setting(containerEl)
 			.setName("Display definition source file")
 			.setDesc("Display the title of the definition's source file")
-			.addToggle((component) => {
-				component.setValue(
-					this.settings.defPopoverConfig.displayDefFileName,
-				);
-				component.onChange(async (value) => {
+			.addToggle(component => {
+				component.setValue(this.settings.defPopoverConfig.displayDefFileName);
+				component.onChange(async value => {
 					this.settings.defPopoverConfig.displayDefFileName = value;
 					await this.saveCallback();
 				});
@@ -360,14 +258,10 @@ export class SettingsTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Custom popover size")
-			.setDesc(
-				"Customise the maximum popover size. This is not recommended as it prevents dynamic sizing of the popover based on your viewport.",
-			)
-			.addToggle((component) => {
-				component.setValue(
-					this.settings.defPopoverConfig.enableCustomSize,
-				);
-				component.onChange(async (value) => {
+			.setDesc("Customise the maximum popover size. This is not recommended as it prevents dynamic sizing of the popover based on your viewport.")
+			.addToggle(component => {
+				component.setValue(this.settings.defPopoverConfig.enableCustomSize);
+				component.onChange(async value => {
 					this.settings.defPopoverConfig.enableCustomSize = value;
 					await this.saveCallback();
 					this.display();
@@ -378,11 +272,11 @@ export class SettingsTab extends PluginSettingTab {
 			new Setting(containerEl)
 				.setName("Popover width (px)")
 				.setDesc("Maximum width of the definition popover")
-				.addSlider((component) => {
+				.addSlider(component => {
 					component.setLimits(150, window.innerWidth, 1);
 					component.setValue(this.settings.defPopoverConfig.maxWidth);
-					component.setDynamicTooltip();
-					component.onChange(async (val) => {
+					component.setDynamicTooltip()
+					component.onChange(async val => {
 						this.settings.defPopoverConfig.maxWidth = val;
 						await this.saveCallback();
 					});
@@ -391,13 +285,11 @@ export class SettingsTab extends PluginSettingTab {
 			new Setting(containerEl)
 				.setName("Popover height (px)")
 				.setDesc("Maximum height of the definition popover")
-				.addSlider((component) => {
+				.addSlider(component => {
 					component.setLimits(150, window.innerHeight, 1);
-					component.setValue(
-						this.settings.defPopoverConfig.maxHeight,
-					);
+					component.setValue(this.settings.defPopoverConfig.maxHeight);
 					component.setDynamicTooltip();
-					component.onChange(async (val) => {
+					component.onChange(async val => {
 						this.settings.defPopoverConfig.maxHeight = val;
 						await this.saveCallback();
 					});
@@ -406,14 +298,10 @@ export class SettingsTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Enable definition links")
-			.setDesc(
-				"Definitions within popovers will be marked and can be clicked to go to definition.",
-			)
-			.addToggle((component) => {
-				component.setValue(
-					this.settings.defPopoverConfig.enableDefinitionLink,
-				);
-				component.onChange(async (val) => {
+			.setDesc("Definitions within popovers will be marked and can be clicked to go to definition.")
+			.addToggle(component => {
+				component.setValue(this.settings.defPopoverConfig.enableDefinitionLink);
+				component.onChange(async val => {
 					this.settings.defPopoverConfig.enableDefinitionLink = val;
 					await this.saveCallback();
 				});
@@ -421,10 +309,8 @@ export class SettingsTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Background colour")
-			.setDesc(
-				"Customise the background colour of the definition popover",
-			)
-			.addExtraButton((component) => {
+			.setDesc("Customise the background colour of the definition popover")
+			.addExtraButton(component => {
 				component.setIcon("rotate-ccw");
 				component.setTooltip("Reset to default colour set by theme");
 				component.onClick(async () => {
@@ -433,16 +319,14 @@ export class SettingsTab extends PluginSettingTab {
 					this.display();
 				});
 			})
-			.addColorPicker((component) => {
+			.addColorPicker(component => {
 				if (this.settings.defPopoverConfig.backgroundColour) {
-					component.setValue(
-						this.settings.defPopoverConfig.backgroundColour,
-					);
+					component.setValue(this.settings.defPopoverConfig.backgroundColour);
 				}
-				component.onChange(async (val) => {
+				component.onChange(async val => {
 					this.settings.defPopoverConfig.backgroundColour = val;
 					await this.saveCallback();
-				});
+				})
 			});
 	}
 }


### PR DESCRIPTION
Closes #163.

Allows users to submit both the add and edit definition modals using Ctrl+Enter and makes the default definition file picking from #154 work when using a folder with atomic definitions.

The intention with both of this change is to make the process of adding a definition as quick and as seamless as possible, not requiring a user to take their hands away from the keyboard to find their mouse. ~The automatic selection is on by default, but it can absolutely be changed if need be. I'm also open to any other feedback (like on the method for selecting either consolidated or atomic).~ reverted.

I'll probably take a swing at some of the larger, more prevalent issues when I have more time, but I wanted to make another small PR with some nice workflow changes in the meantime.