### PR TITLE
fix: support Hangul word boundaries in mixed-script text

### DIFF
--- a/src/editor/definition-search.ts
+++ b/src/editor/definition-search.ts
@@ -12,7 +12,8 @@ export interface PhraseInfo {
 export class LineScanner {
 	prefixTree: PTreeNode;
 
-	private cnLangRegex = /\p{Script=Han}/u;
+	private cjkCharRegex =
+		/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}ー]/u;
 	private terminatingCharRegex =
 		/[!@#$%^&*()\+={}[\]:;"'<>,.?\/|\\\r\n （）＊＋，－／：；＜＝＞＠［＼］＾＿｀｛｜｝～｟｠｢｣､　、〃〈〉《》「」『』【】〔〕〖〗〘〙〚〛〜〝〞〟—‘’‛“”„‟…‧﹏﹑﹔·。]/;
 
@@ -25,11 +26,10 @@ export class LineScanner {
 		const phraseInfos: PhraseInfo[] = [];
 
 		for (let i = 0; i < line.length; i++) {
-			let c="";
+			let c = "";
 			if (getSettings().defFileParseConfig.enableCaseSensitive) {
 				c = line.charAt(i);
-			}
-			else {
+			} else {
 				c = line.charAt(i).toLowerCase();
 			}
 			if (this.isValidStart(line, i)) {
@@ -57,44 +57,50 @@ export class LineScanner {
 	}
 
 	private isValidEnd(line: string, ptr: number): boolean {
-		let c="";
+		let c = "";
 		if (getSettings().defFileParseConfig.enableCaseSensitive) {
 			c = line.charAt(ptr);
-		}
-		else {
+		} else {
 			c = line.charAt(ptr).toLowerCase();
 		}
-		if (this.isNonSpacedLanguage(c)) {
+		if (this.isCjkCharacter(c)) {
 			return true;
 		}
 		// If EOL, then it is a valid end
 		if (ptr === line.length - 1) {
 			return true;
 		}
-		// Check if next character is a terminating character
-		return this.terminatingCharRegex.test(line.charAt(ptr + 1));
+		// CJK text and Korean particles can directly follow a definition.
+		const nextChar = line.charAt(ptr + 1);
+		return (
+			this.terminatingCharRegex.test(nextChar) ||
+			this.isCjkCharacter(nextChar)
+		);
 	}
 
 	// Check if this character is a valid start of a word depending on the context
 	private isValidStart(line: string, ptr: number): boolean {
-		let c="";
+		let c = "";
 		if (getSettings().defFileParseConfig.enableCaseSensitive) {
 			c = line.charAt(ptr);
-		}
-		else {
+		} else {
 			c = line.charAt(ptr).toLowerCase();
 		}
 		if (c == " ") {
 			return false;
 		}
-		if (ptr === 0 || this.isNonSpacedLanguage(c)) {
+		if (ptr === 0 || this.isCjkCharacter(c)) {
 			return true;
 		}
-		// Check if previous character is a terminating character
-		return this.terminatingCharRegex.test(line.charAt(ptr - 1));
+		// Latin definitions can directly follow CJK text without a space.
+		const previousChar = line.charAt(ptr - 1);
+		return (
+			this.terminatingCharRegex.test(previousChar) ||
+			this.isCjkCharacter(previousChar)
+		);
 	}
 
-	private isNonSpacedLanguage(c: string): boolean {
-		return this.cnLangRegex.test(c);
+	private isCjkCharacter(c: string): boolean {
+		return this.cjkCharRegex.test(c);
 	}
 }

--- a/src/tests/decorator.test.ts
+++ b/src/tests/decorator.test.ts
@@ -95,3 +95,47 @@ test("Definitions that are a subset of another are detected correctly. The longe
 	];
 	expect(phraseInfo).toStrictEqual(expectedPhraseInfo);
 });
+
+test("Latin definitions are detected when followed by a Hangul particle", () => {
+	const mixedScriptTree = new PTreeNode();
+	mixedScriptTree.add("classpath");
+	const text = "JVM은 CLASSPATH에서 클래스를 찾는다.";
+	const from = text.indexOf("CLASSPATH");
+
+	expect(scanText(text, 0, mixedScriptTree)).toStrictEqual([
+		{
+			phrase: "classpath",
+			from,
+			to: from + "CLASSPATH".length,
+		},
+	]);
+});
+
+test("Hangul definitions are detected when followed by a particle", () => {
+	const hangulTree = new PTreeNode();
+	hangulTree.add("클래스패스");
+	const text = "클래스패스에서 클래스를 찾는다.";
+
+	expect(scanText(text, 0, hangulTree)).toStrictEqual([
+		{
+			phrase: "클래스패스",
+			from: 0,
+			to: "클래스패스".length,
+		},
+	]);
+});
+
+test("Latin definitions are detected between CJK characters", () => {
+	const mixedScriptTree = new PTreeNode();
+	mixedScriptTree.add("templater");
+	const text = "插件Templater에서 사용한다.";
+	const from = text.indexOf("Templater");
+
+	expect(scanText(text, 0, mixedScriptTree)).toStrictEqual([
+		{
+			phrase: "templater",
+			from,
+			to: from + "Templater".length,
+		},
+	]);
+});


### PR DESCRIPTION
## Summary

  This PR adds Hangul-aware word boundary detection to the definition scanner.

  Korean particles are normally attached directly to words without whitespace. As a result, definitions such as `CLASSPATH` were not detected in
  text like `CLASSPATH에서`, even though `CLASSPATH 에서` worked.

  ## Changes

  - Add Hangul to the CJK character detection regex.
  - Treat transitions between Latin and CJK/Hangul characters as valid word boundaries.
  - Detect Latin definitions followed directly by Korean particles.
  - Detect Hangul definitions followed directly by Korean particles.
  - Preserve support for mixed Chinese, Japanese, and Latin text.
  - Add regression tests for mixed-script boundary cases.

  ## Examples

  The following definitions are now detected:

  - `CLASSPATH` in `CLASSPATH에서`
  - `클래스패스` in `클래스패스에서`
  - `Templater` when placed directly between CJK characters

  ## Tests

  - `npm test -- --runInBand`
    - 3 test suites passed
    - 20 tests passed
  - `npm run build`
    - Build completed successfully

  ## Related issues

  Related to #16 and #38, which addressed mixed Chinese and English definition detection.